### PR TITLE
Speed up subsequent requests with --cached option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,70 @@ You can also override some of the underlying options saved in the registry:
 $ pot --registered <register_name> --repository_names 'some, other, repos'
 ```
 
+# Speeding up
+There is the option of caching raw data returned from github for future use,
+which significantly speeds up further responses. For example, running:
+
+```sh
+$ pot --users=john,jane,doe
+```
+
+And then, wanting to know more about a specific user through the detailed view:
+
+```sh
+$ pot --user=doe --cached
+```
+
+This way, for the second command, no request is made, the data is considered to
+be the same.
+
+To enable this feature, run the config wizard. If enabled, the raw data from
+the request(s) are stored in `pot_root_folder/cached_response` everytime the command
+sends a request to github. Results are cached under the repo names used
+in the command. If different repo names are used, the request is made and its
+response is **also** saved in the aforementioned file.
+
+e.g.
+
+Assume the cache was just enabled (`cache_enabled: true` in the config file).
+
+Note: The `--cached` option specifies that we want to use the cached response, if
+present. If not present, the request is made as if `--cached` was ommited.
+
+This **sends** the request and saves the raw response:
+
+```sh
+$ pot --users=jane,doe --repository_names=octo --cached
+```
+
+This **also sends** the request and saves the raw response under a different key:
+
+```sh
+$ pot --users=jane,doe --repository_names=octo,cat --cached
+```
+
+Subsequent requests made with the repositories being `octo`, `octo,cat` or `cat, octo` and the `--cached` option will use the cached response from the previous requests.
+For example, the following command will **not** trigger a request:
+
+```sh
+$ pot --users=john --repository_names=octo,cat --cached
+```
+```sh
+$ pot --users=jane --repository_names=cat,octo --cached
+```
+```sh
+$ pot --users=doe --repository_names=octo --cached
+```
+
+But this one will, since response for repo `cat` alone has not been received so
+far:
+```sh
+$ pot --users=doe --repository_names=cat --cached
+```
+
+Note: `--cached` is not saved when using `--register` [See `register`](#register)
+
+
 # Contributing
 
 1. Create an issue describing the purpose of the pull request unless there is one already

--- a/bin/pot
+++ b/bin/pot
@@ -187,6 +187,13 @@ OptionParser.new do |opts|
     options[:registered] = true
     options[:registered_name] = value
   end
+
+  opts.on(
+    '--cached',
+    'Uses the already cached data from the previous request to speed up the response'
+  ) do |value|
+    options[:cached] = true
+  end
 end.parse!
 
 def prs

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -51,7 +51,7 @@ class Config
     all_registered_configs[register_name] = {}
 
     options.keys.each do |key|
-      next if [:register_new, :registered_name, :registered].include?(key)
+      next if [:register_new, :registered_name, :registered, :cached].include?(key)
 
       all_registered_configs[register_name][key.to_s] = options[key]
     end

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -69,6 +69,10 @@ class Config
     @cache_enabled = !!config['cache_enabled']
   end
 
+  def config_folder_path
+    CONFIG_FOLDER_PATH
+  end
+
   private
 
   def save_config

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -28,6 +28,10 @@ class Config
     input = gets.strip
     @owner_name  = input if input.size > 0
 
+    print 'Would you like to cache data to speed up subsequent requests (with --cached) (y/n): '
+    input = gets.strip
+    @cache_enabled = input.downcase[0] == 'y' if input.size > 0
+
     save_config
   end
 
@@ -59,6 +63,12 @@ class Config
     all_registered_configs[register_name]
   end
 
+  def cache_enabled?
+    return @cache_enabled if !@cache_enabled.nil?
+
+    @cache_enabled = !!config['cache_enabled']
+  end
+
   private
 
   def save_config
@@ -68,6 +78,7 @@ class Config
         github_url: github_url,
         repository_names: repository_names,
         owner_name: owner_name,
+        cache_enabled: cache_enabled?,
         registered: all_registered_configs
       })
     )


### PR DESCRIPTION
Cache response and use in subsequent requeests, where applicable, with --cached option.

Closes #21