### PR TITLE
Add relevant users according to user prs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ $ pot --user=doe
 | User | Authored | Reviewing | Total |  Total + / -  | Actionables | Actionable  + / - | Untouched |
 +------+----------+-----------+-------+---------------+-------------+-------------------+-----------+
 | doe  | 2        | 3         | 5     | 5287 / 2095   | 3           | 5270 / 2035       | 1         |
+| john | 3        | 2         | 5     | 5287 / 2095   | 1           | 5270 / 2035       | 1         |
 +------+----------+-----------+-------+---------------+-------------+-------------------+-----------+
 
 +------------+-----------+-------------+---------------------------+
@@ -141,7 +142,12 @@ And both the accumulative and the specific output will be shown
 In the above example, the accumulative data is shown for user `doe`, as well
 as some details about each of the PRs they are involved in. This can be used by
 `doe` to figure out which PR needs their attention first, or by another user
-who happened to have some idle time and wants to help out.
+who happened to have some idle time and wants to help out. Information about
+`john` appear as well, since john is the author of all the PRs that `doe` is
+reviewing, and is also reviewing all PRs that `doe` has authored. This allows
+one to simply pass the `--user` argument and get information on the status of all
+users with which they share any PRs, without explicitly passing a `--users`
+argument.
 
 #### Approvals
 The ratio of users who have approved the PR, to all users ever involved in the PR.

--- a/lib/aggregated_data.rb
+++ b/lib/aggregated_data.rb
@@ -50,6 +50,10 @@ class AggregatedData
     @actionables_count_per_author ||= Hash.new { 0 }
   end
 
+  def relevant_users_according_to_specified_user
+    @relevant_users_according_to_specified_user ||= []
+  end
+
   private
 
   def populate
@@ -61,11 +65,13 @@ class AggregatedData
       if pr.author == user
         actionable = pr.author_actionable?
         add_to_specified_user_prs(pr, actionable, :authored)
+        relevant_users_according_to_specified_user.push(*pr.active_reviewers)
       end
 
       if pr.active_reviewers.include?(user)
         actionable = pr.reviewer_actionable?(user: user)
         add_to_specified_user_prs(pr, actionable, :reviewing)
+        relevant_users_according_to_specified_user.push(pr.author)
       end
 
       # Increment actionable counts

--- a/lib/printer.rb
+++ b/lib/printer.rb
@@ -152,6 +152,11 @@ class Printer
     users = options[:users]&.split(',') || []
 
     @users_to_include = users.push(options[:user]).compact
+    @users_to_include.push(*aggregated_data.relevant_users_according_to_specified_user)
+
+    @users_to_include.uniq!
+
+    @users_to_include
   end
 
   def pr_users


### PR DESCRIPTION
Print information about all users relevant to the user specified in the
options so that it is not necessary to explicitly add them to the
options passed to pot.

Closes #41 