### PR TITLE
V2.0 use gh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 *.swp

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format progress
+--color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+2.0.0 January, 10, 2026
+ - **BREAKING**: Replaced direct GitHub GraphQL HTTP API with GitHub CLI (`gh`) for improved reliability
+ - **BREAKING**: Requires GitHub CLI (`gh`) v2.0+ to be installed and authenticated
+ - **NEW**: Authentication is now managed by GitHub CLI (`gh auth login`) instead of environment variables
+ - **IMPROVED**: Significantly improved reliability - eliminated timeout issues with the deprecated GraphQL API
+ - **IMPROVED**: Built-in rate limit handling via GitHub CLI
+ - **IMPROVED**: Better error messages and automatic error handling
+ - **IMPROVED**: Comprehensive unit tests
+ - **REMOVED**: `GAT` environment variable is no longer used or required
+ - **REMOVED**: Direct HTTP/GraphQL implementation code
+ - Dependencies: Added RSpec for testing (development only)
+ - Internal refactor: Updated `GithubClient` to use subprocess execution via `Open3`
+ - Documentation: Updated README with new prerequisites and troubleshooting guide
+
 1.2.1 June, 21, 2022
  - Make specified user more visible in aggregated view.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,20 @@ Before installing `pot`, ensure you have the following:
 
 1. **GitHub CLI (`gh`)** - The official GitHub command-line tool
    - Download from: https://cli.github.com
-   - After installation, authenticate with:
+   - Minimum version: `gh` v2.0+ (to ensure all required JSON field options are available)
+   - After installation, verify it's working:
+     ```sh
+     gh --version
+     ```
+   - Authenticate with:
      ```sh
      gh auth login
      ```
    - Follow the interactive prompts to complete authentication
+   - Verify authentication with:
+     ```sh
+     gh auth status
+     ```
 
 2. **Ruby** - `pot` is a Ruby gem (typically Ruby 2.6+)
 
@@ -203,19 +212,46 @@ $ pot --user=doe --url-only | xargs -L1 xdg-open
 
 
 # Configuration
+
+## GitHub Authentication
+`pot` uses the GitHub CLI (`gh`) for authentication. Credentials are managed by `gh`, not by `pot`.
+
+To authenticate:
 ```sh
-$ pot --config
+$ gh auth login
 ```
-Follow the wizard to define the github url, repository and owner names.
-You can provide all said config options as params, like so:
+
+This step is **required** before using `pot`.
+
+## Repository Configuration
+
+You can provide repository information either via command-line options or by saving a default configuration.
+
+### Option 1: Command-line Options
+
+Provide options each time you run `pot`:
 
 ```sh
 $ pot --user=doe --repository_names "octo, cat" --owner_name 'repo_owner_name'
-
 ```
 
+### Option 2: Save Default Configuration
+
+To save frequently-used repository information:
+
+```sh
+$ pot --config
+```
+
+Follow the interactive wizard to define:
+- **Repository names** (comma-separated): Which repositories to analyze
+- **Owner name**: GitHub user or organization that owns the repositories
+- **Cache enabled**: Whether to cache PR data for faster subsequent runs
+
+The configuration is saved to `~/.pot/config` for future use.
+
 # Register
-In case command is usually being used with certain options, options can be saved
+In case a command is usually being used with certain options, options can be saved
 under a certain name like so:
 
 ```sh
@@ -298,6 +334,34 @@ $ pot --users=doe --repository_names=cat --cached
 
 Note: `--cached` is not saved when using `--register` [See `register`](#register)
 
+
+# Troubleshooting
+
+## GitHub CLI (`gh`) Not Found
+**Error:** `gh: command not found`
+
+**Solution:** Install the GitHub CLI from https://cli.github.com
+
+## Not Authenticated
+**Error:** `Error fetching PRs: authentication required`
+
+**Solution:** Run `gh auth login` and follow the interactive prompts to authenticate with GitHub
+
+## Permission Issues
+**Error:** `Error fetching PRs: insufficient permissions`
+
+**Solution:** Ensure your GitHub credentials have access to the repositories you're querying. Check your GitHub token permissions:
+```sh
+$ gh auth status
+```
+
+## Repository Not Found
+**Error:** `Error fetching PRs: repository not found`
+
+**Solution:** Verify that:
+1. The owner name and repository names are correct
+2. You have access to the repository
+3. The repository exists on GitHub
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A CLI to instantly get an overview of one or more repos' PRs, and decide which PR to act upon next.
 
-![Version badge](https://img.shields.io/badge/version-1.2.1-green.svg)
+![Version badge](https://img.shields.io/badge/version-2.0.0-green.svg)
 
 `pot` stands for Pr Overview Tool
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,22 @@ Note: This is an ongoing project, and issues are frequently opened and closed. R
 # How it works
 
 `pot` creates accumulated data for users concerning one or more repositories, using
-github's graphql api.
+GitHub's API through the official GitHub CLI (`gh`). This provides improved reliability,
+automatic error handling, and built-in rate limit management.
+
+# Prerequisites
+
+Before installing `pot`, ensure you have the following:
+
+1. **GitHub CLI (`gh`)** - The official GitHub command-line tool
+   - Download from: https://cli.github.com
+   - After installation, authenticate with:
+     ```sh
+     gh auth login
+     ```
+   - Follow the interactive prompts to complete authentication
+
+2. **Ruby** - `pot` is a Ruby gem (typically Ruby 2.6+)
 
 # Installation
 
@@ -26,23 +41,40 @@ $ ./install.sh # Installed as a gem
 
 # Usage
 
-Note: Since github needs a personal access token, this token must be accessible
-to `pot`, like so for example:
+`pot` uses the GitHub CLI for authentication, which means your GitHub credentials
+are managed by `gh`.
+
+### Authentication
+
+First, ensure you've authenticated with GitHub CLI:
 
 ```sh
-$ GAT=<your_token> pot <options, etc>
+$ gh auth login
 ```
 
-Or better yet:
+Then simply use `pot` as normal:
 
 ```sh
-$ GAT=`cat pat/to/token/file` pot <options, etc>
+$ pot --users=john,jane,doe
 ```
 
-(GAT -> Github Access Token)
+### All-in-one Setup
 
-In the usage examples following, `GAT` assignment will not be prefixed for
-simplicity.
+For first-time users, here's the complete setup:
+
+```sh
+# 1. Install GitHub CLI (if not already installed)
+# Visit: https://cli.github.com
+
+# 2. Authenticate with GitHub
+$ gh auth login
+
+# 3. Configure pot (one-time setup)
+$ pot --config
+
+# 4. Use pot!
+$ pot --users=john,jane,doe
+```
 
 
 ## Multiple user overview

--- a/bin/pot
+++ b/bin/pot
@@ -6,6 +6,8 @@ require_relative '../lib/config'
 require_relative '../lib/printer'
 
 def main
+  check_gh_installed
+
   if options[:config]
     config.init
 
@@ -26,6 +28,26 @@ end
 
 def options
   @options ||= {}
+end
+
+def check_gh_installed
+  unless system('gh --version > /dev/null 2>&1')
+    puts <<~ERROR
+      ❌ Error: GitHub CLI (gh) is not installed or not accessible.
+
+      pot now requires the GitHub CLI to function properly. This improves
+      reliability and provides better error handling.
+
+      Please install GitHub CLI from: https://cli.github.com
+
+      After installation, you'll need to authenticate:
+        gh auth login
+
+      Then you can use pot as usual:
+        pot --users=john,jane --user=john
+    ERROR
+    exit(1)
+  end
 end
 
 OptionParser.new do |opts|

--- a/bin/pot
+++ b/bin/pot
@@ -51,7 +51,7 @@ def check_gh_installed
 end
 
 OptionParser.new do |opts|
-  opts.banner = 'GAT=<your_github_access_token> [--users=some,user,names] [--user=user_name]'
+  opts.banner = 'pot [--users=some,user,names] [--user=user_name] [options]'
 
   opts.on('--config', '--configure', 'Outputs only the urls of the PRs authored and the PRs to be reviewed') do
     options[:config] = true

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 gem build pot.gemspec
-gem install --local pot
-rm pot-1.2.1.gem
+gem install --local pot --user-install
+rm pot-2.0.0.gem

--- a/lib/pot/version.rb
+++ b/lib/pot/version.rb
@@ -1,3 +1,3 @@
 module Pot
-  VERSION = "0.1.0"
+  VERSION = "2.0.0"
 end

--- a/lib/pr.rb
+++ b/lib/pr.rb
@@ -2,7 +2,7 @@ class Pr
   attr_reader :hash
 
   def initialize(hash)
-    @hash = hash['node']
+    @hash = hash
   end
 
   def author
@@ -35,8 +35,8 @@ class Pr
 
   def requested_reviewers
     @requested_reviewers ||=
-      hash['reviewRequests']['edges'].map do |review|
-        review['node']['requestedReviewer']['login']
+      (hash['reviewRequests'] || []).map do |review_request|
+        review_request['login']
       end
   end
 
@@ -101,11 +101,11 @@ class Pr
   end
 
   def reviews
-    @reviews ||= hash['reviews']['edges'].map do |review|
+    @reviews ||= (hash['reviews'] || []).map do |review|
       {
-        author: review['node']['author']['login'],
-        state: review['node']['state'],
-        created_at: Date.strptime(review['node']['createdAt'], '%Y-%m-%d')
+        author: review['author']['login'],
+        state: review['state'],
+        created_at: Date.parse(review['submittedAt'])
       }
     end
   end

--- a/lib/services/github_client.rb
+++ b/lib/services/github_client.rb
@@ -12,6 +12,7 @@ class GithubClient
 
   def initialize(options: )
     @options = options
+    check_gh_installed
   end
 
   # Returns an array of hashes, each hash containing information on a pr
@@ -47,6 +48,26 @@ class GithubClient
   end
 
   private
+
+  def check_gh_installed
+    unless system('gh --version > /dev/null 2>&1')
+      puts <<~ERROR
+        ❌ Error: GitHub CLI (gh) is not installed or not accessible.
+
+        pot now requires the GitHub CLI to function properly. This improves
+        reliability and provides better error handling.
+
+        Please install GitHub CLI from: https://cli.github.com
+
+        After installation, you'll need to authenticate:
+          gh auth login
+
+        Then you can use pot as usual:
+          pot --users=john,jane --user=john
+      ERROR
+      exit(1)
+    end
+  end
 
   def next_request(last_cursor, repository_name)
     request = Net::HTTP::Post.new(uri)

--- a/lib/services/github_client.rb
+++ b/lib/services/github_client.rb
@@ -1,7 +1,6 @@
-require 'net/http'
-require 'uri'
 require 'json'
 require 'date'
+require 'open3'
 
 require_relative '../config'
 
@@ -15,7 +14,8 @@ class GithubClient
     check_gh_installed
   end
 
-  # Returns an array of hashes, each hash containing information on a pr
+  # Returns an array of hashes from gh pr list, each hash containing PR data
+  # Format: [{ title, url, author, additions, deletions, reviews, reviewRequests, ... }, ...]
   def prs
     return cached_response if options[:cached] && cached_response
 
@@ -29,17 +29,8 @@ class GithubClient
     end
 
     repository_names.each do |repository_name|
-      has_next = true
-      last_cursor = nil
-
-      while has_next
-        response = next_request(last_cursor, repository_name)
-        has_next = response['pageInfo']['hasNextPage']
-
-        _prs += response['edges']
-
-        last_cursor = _prs.last&.dig('cursor')&.gsub(/=*$/, '')
-      end
+      gh_prs = fetch_prs_from_gh(repository_name)
+      _prs += gh_prs
     end
 
     write_cached_response(_prs) if config.cache_enabled?
@@ -69,14 +60,7 @@ class GithubClient
     end
   end
 
-  def next_request(last_cursor, repository_name)
-    request = Net::HTTP::Post.new(uri)
-    request['Authorization'] = "bearer #{ENV['GAT']}"
-
-    if last_cursor
-      after = ", after: \"#{last_cursor}\""
-    end
-
+  def fetch_prs_from_gh(repository_name)
     if owner_name.nil? || owner_name == ''
       puts 'Attribute owner_name must be provided either through the' \
         ' config, or through an option'
@@ -84,29 +68,29 @@ class GithubClient
       exit(1)
     end
 
-    request.body = JSON.dump({
-      'query' => "query { repository(owner: \"#{owner_name}\", name: \"#{repository_name}\") { pullRequests(first: 80, states: OPEN#{after}) { pageInfo { hasNextPage } edges { cursor node { additions deletions reviews(first: 80) { edges { node { author { login } state createdAt }  } } reviewRequests(first: 80) { edges { node { requestedReviewer { ... on User { login } } } } } url title author { login } participants(first: 80) { edges { node { login } } } } } } } }"
-    })
+    repo = "#{owner_name}/#{repository_name}"
 
-    req_options = {
-      use_ssl: uri.scheme == 'https'
-    }
+    # Specify all JSON fields we need, including nested review/reviewRequest data
+    json_fields = 'number,title,url,author,additions,deletions,reviews,reviewRequests'
 
-    response = Net::HTTP.start(uri.hostname, uri.port, req_options) do |http|
-      http.request(request)
+    cmd = "gh pr list --repo #{repo} --state open --json #{json_fields} --limit 100"
+
+    stdout, stderr, status = Open3.capture3(cmd)
+
+    unless status.success?
+      puts "Error fetching PRs for #{repo}:"
+      puts stderr
+      exit(1)
     end
 
-    JSON.parse(response.body)['data']['repository']['pullRequests']
+    JSON.parse(stdout)
+  rescue JSON::ParserError => e
+    puts "Error parsing gh output for #{repo}: #{e.message}"
+    exit(1)
   end
-
-  private
 
   def cached_response
     cached_responses_full[cached_response_key]
-  end
-
-  def github_url
-    'https://api.github.com/graphql'
   end
 
   def repository_names
@@ -115,10 +99,6 @@ class GithubClient
 
   def owner_name
     options[:owner_name] || config.owner_name
-  end
-
-  def uri
-    @uri ||= URI.parse(github_url)
   end
 
   def write_cached_response(data)

--- a/pot.gemspec
+++ b/pot.gemspec
@@ -5,12 +5,12 @@ require 'pot/version'
 
 Gem::Specification.new do |spec|
   spec.name          = "pot"
-  spec.version       = "1.2.1"
+  spec.version       = "2.0.0"
   spec.authors       = ["Giannis Poulis"]
   spec.email         = ["ioanniswd@gmail.com"]
 
   spec.summary       = %q{A tool to get an overview of current PRs to better distribute load amongst devs}
-  spec.description   = %q{`pot` creates accumulated data for users concerning one repository, using github's graphql api}
+  spec.description   = %q{`pot` creates accumulated data for users concerning one or more repositories, using the GitHub CLI (`gh`)}
   spec.homepage      = "https://github.com/ioanniswd/pot"
   spec.license       = "MIT"
 

--- a/pot.gemspec
+++ b/pot.gemspec
@@ -28,8 +28,9 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "terminal-table", "~> 1.8"
+  spec.add_development_dependency "bundler", ">= 1.13"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_development_dependency "terminal-table", ">= 1.8"
+  spec.add_development_dependency "rspec", "~> 3.12"
   spec.executables << 'pot'
 end

--- a/spec/fixtures/approval_after_review_request_after_approval.json
+++ b/spec/fixtures/approval_after_review_request_after_approval.json
@@ -1,0 +1,78 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXf1l",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "Re-requesting changes to simulate an ongoing PR and check gh pr list output",
+        "submittedAt": "2026-01-10T13:06:57Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXgy_",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "",
+        "submittedAt": "2026-01-10T13:09:52Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "APPROVED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXhjI",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "Final approval",
+        "submittedAt": "2026-01-10T13:11:39Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "APPROVED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/approved_after_requested_changes.json
+++ b/spec/fixtures/approved_after_requested_changes.json
@@ -1,0 +1,63 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXf1l",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "Re-requesting changes to simulate an ongoing PR and check gh pr list output",
+        "submittedAt": "2026-01-10T13:06:57Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXgy_",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "",
+        "submittedAt": "2026-01-10T13:09:52Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "APPROVED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/gh_prs_complex.json
+++ b/spec/fixtures/gh_prs_complex.json
@@ -1,0 +1,86 @@
+[
+  {
+    "number": 42,
+    "title": "Add feature X",
+    "url": "https://github.com/test/repo/pull/42",
+    "author": {
+      "login": "alice"
+    },
+    "additions": 120,
+    "deletions": 45,
+    "reviews": [
+      {
+        "author": {
+          "login": "bob"
+        },
+        "state": "APPROVED",
+        "submittedAt": "2025-01-08T10:30:00Z"
+      },
+      {
+        "author": {
+          "login": "charlie"
+        },
+        "state": "COMMENTED",
+        "submittedAt": "2025-01-08T11:15:00Z"
+      }
+    ],
+    "reviewRequests": [
+      {
+        "login": "david"
+      }
+    ]
+  },
+  {
+    "number": 43,
+    "title": "Fix bug Y",
+    "url": "https://github.com/test/repo/pull/43",
+    "author": {
+      "login": "bob"
+    },
+    "additions": 15,
+    "deletions": 8,
+    "reviews": [
+      {
+        "author": {
+          "login": "alice"
+        },
+        "state": "CHANGES_REQUESTED",
+        "submittedAt": "2025-01-09T09:00:00Z"
+      },
+      {
+        "author": {
+          "login": "alice"
+        },
+        "state": "APPROVED",
+        "submittedAt": "2025-01-09T14:30:00Z"
+      },
+      {
+        "author": {
+          "login": "charlie"
+        },
+        "state": "COMMENTED",
+        "submittedAt": "2025-01-09T15:00:00Z"
+      }
+    ],
+    "reviewRequests": []
+  },
+  {
+    "number": 44,
+    "title": "Refactor module Z",
+    "url": "https://github.com/test/repo/pull/44",
+    "author": {
+      "login": "charlie"
+    },
+    "additions": 200,
+    "deletions": 150,
+    "reviews": [],
+    "reviewRequests": [
+      {
+        "login": "alice"
+      },
+      {
+        "login": "bob"
+      }
+    ]
+  }
+]

--- a/spec/fixtures/gh_prs_simple.json
+++ b/spec/fixtures/gh_prs_simple.json
@@ -1,0 +1,14 @@
+[
+  {
+    "number": 1,
+    "title": "Simple PR with no reviews",
+    "url": "https://github.com/test/repo/pull/1",
+    "author": {
+      "login": "alice"
+    },
+    "additions": 50,
+    "deletions": 20,
+    "reviews": [],
+    "reviewRequests": []
+  }
+]

--- a/spec/fixtures/re_request_review_after_approval.json
+++ b/spec/fixtures/re_request_review_after_approval.json
@@ -1,0 +1,68 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [
+      {
+        "__typename": "User",
+        "login": "ioanniswd-bot"
+      }
+    ],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXf1l",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "Re-requesting changes to simulate an ongoing PR and check gh pr list output",
+        "submittedAt": "2026-01-10T13:06:57Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXgy_",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "",
+        "submittedAt": "2026-01-10T13:09:52Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "APPROVED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/re_requesting_changes_after_re_requesting_review.json
+++ b/spec/fixtures/re_requesting_changes_after_re_requesting_review.json
@@ -1,0 +1,48 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXf1l",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "Re-requesting changes to simulate an ongoing PR and check gh pr list output",
+        "submittedAt": "2026-01-10T13:06:57Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/re_requesting_review_after_re_requesting_changes.json
+++ b/spec/fixtures/re_requesting_review_after_re_requesting_changes.json
@@ -1,0 +1,53 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [
+      {
+        "__typename": "User",
+        "login": "ioanniswd-bot"
+      }
+    ],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      },
+      {
+        "id": "PRR_kwDOD_0z0c7ZXf1l",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "Re-requesting changes to simulate an ongoing PR and check gh pr list output",
+        "submittedAt": "2026-01-10T13:06:57Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/re_requesting_review_after_requested_changes.json
+++ b/spec/fixtures/re_requesting_review_after_requested_changes.json
@@ -1,0 +1,38 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [
+      {
+        "__typename": "User",
+        "login": "ioanniswd-bot"
+      }
+    ],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/requested_changes_first_time.json
+++ b/spec/fixtures/requested_changes_first_time.json
@@ -1,0 +1,33 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [],
+    "reviews": [
+      {
+        "id": "PRR_kwDOD_0z0c7ZXeH1",
+        "author": {
+          "login": "ioanniswd-bot"
+        },
+        "authorAssociation": "COLLABORATOR",
+        "body": "bot-test: Make sure the active reviewers are correctly handled, especially after re-requesting a review after their approval.",
+        "submittedAt": "2026-01-10T13:01:51Z",
+        "includesCreatedEdit": false,
+        "reactionGroups": [],
+        "state": "CHANGES_REQUESTED",
+        "commit": {
+          "oid": "0e426056edb45a36b66377c3aacb4db6cb5403d1"
+        }
+      }
+    ],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/fixtures/requested_review_open_pr.json
+++ b/spec/fixtures/requested_review_open_pr.json
@@ -1,0 +1,22 @@
+[
+  {
+    "additions": 513,
+    "author": {
+      "id": "MDQ6VXNlcjE4MjEzNTEy",
+      "is_bot": false,
+      "login": "ioanniswd",
+      "name": "John Poulis"
+    },
+    "deletions": 58,
+    "number": 43,
+    "reviewRequests": [
+      {
+        "__typename": "User",
+        "login": "ioanniswd-bot"
+      }
+    ],
+    "reviews": [],
+    "title": "V2.0 use gh",
+    "url": "https://github.com/ioanniswd/pot/pull/43"
+  }
+]

--- a/spec/lib/github_client_spec.rb
+++ b/spec/lib/github_client_spec.rb
@@ -1,0 +1,131 @@
+require_relative '../spec_helper'
+require 'open3'
+
+describe 'GithubClient class' do
+  describe 'fetch_prs_from_gh method' do
+    let(:mock_options) do
+      {
+        owner_name: 'test-owner',
+        repository_names: 'test-repo'
+      }
+    end
+
+    it 'parses gh JSON output correctly' do
+      fixture_data = load_fixture('gh_prs_complex.json')
+      mock_stdout = JSON.dump(fixture_data)
+      mock_status = instance_double('Process::Status', success?: true)
+
+      allow(Open3).to receive(:capture3).and_return([mock_stdout, '', mock_status])
+
+      client = GithubClient.new(options: mock_options)
+      result = client.send(:fetch_prs_from_gh, 'test-repo')
+
+      expect(result.length).to eq(3)
+      expect(result.first['author']['login']).to eq('alice')
+      expect(result.first['title']).to eq('Add feature X')
+    end
+
+    it 'handles empty PR list' do
+      mock_stdout = JSON.dump([])
+      mock_status = instance_double('Process::Status', success?: true)
+
+      allow(Open3).to receive(:capture3).and_return([mock_stdout, '', mock_status])
+
+      client = GithubClient.new(options: mock_options)
+      result = client.send(:fetch_prs_from_gh, 'test-repo')
+
+      expect(result).to eq([])
+    end
+
+    it 'exits on gh command failure' do
+      mock_status = instance_double('Process::Status', success?: false)
+
+      allow(Open3).to receive(:capture3).and_return(['', 'Error: not found', mock_status])
+
+      client = GithubClient.new(options: mock_options)
+
+      expect { client.send(:fetch_prs_from_gh, 'test-repo') }.to raise_error(SystemExit)
+    end
+
+    it 'exits on JSON parse error' do
+      mock_stdout = 'invalid json {'
+      mock_status = instance_double('Process::Status', success?: true)
+
+      allow(Open3).to receive(:capture3).and_return([mock_stdout, '', mock_status])
+
+      client = GithubClient.new(options: mock_options)
+
+      expect { client.send(:fetch_prs_from_gh, 'test-repo') }.to raise_error(SystemExit)
+    end
+
+    it 'constructs correct gh command' do
+      mock_stdout = JSON.dump([])
+      mock_status = instance_double('Process::Status', success?: true)
+
+      allow(Open3).to receive(:capture3) do |cmd|
+        expect(cmd).to include('gh pr list')
+        expect(cmd).to include('--repo test-owner/test-repo')
+        expect(cmd).to include('--state open')
+        expect(cmd).to include('--json')
+        expect(cmd).to include('number,title,url,author,additions,deletions,reviews,reviewRequests')
+        expect(cmd).to include('--limit 100')
+
+        [mock_stdout, '', mock_status]
+      end
+
+      client = GithubClient.new(options: mock_options)
+      client.send(:fetch_prs_from_gh, 'test-repo')
+    end
+  end
+
+  describe 'prs method through fetch_prs_from_gh' do
+    let(:mock_options) do
+      {
+        owner_name: 'test-owner',
+        repository_names: 'test-repo1,test-repo2'
+      }
+    end
+
+    it 'returns flattened PRs from multiple repositories' do
+      fixture_data_1 = load_fixture('gh_prs_simple.json')
+      fixture_data_2 = load_fixture('gh_prs_complex.json')
+
+      mock_status = instance_double('Process::Status', success?: true)
+      call_count = 0
+
+      allow(Open3).to receive(:capture3) do
+        call_count += 1
+        case call_count
+        when 1
+          [JSON.dump(fixture_data_1), '', mock_status]
+        when 2
+          [JSON.dump(fixture_data_2), '', mock_status]
+        end
+      end
+
+      client = GithubClient.new(options: mock_options)
+      result = client.send(:fetch_prs_from_gh, 'test-repo1')
+      result += client.send(:fetch_prs_from_gh, 'test-repo2')
+
+      expect(result.length).to eq(4) # 1 from first repo + 3 from second
+    end
+
+    it 'returns PRs as Pr objects when called through aggregated_data flow' do
+      fixture_data = load_fixture('gh_prs_complex.json')
+      mock_status = instance_double('Process::Status', success?: true)
+
+      allow(Open3).to receive(:capture3).and_return([JSON.dump(fixture_data), '', mock_status])
+
+      client = GithubClient.new(options: mock_options)
+      pr_hashes = client.send(:fetch_prs_from_gh, 'test-repo')
+
+      # Convert to Pr objects like aggregated_data does
+      prs = pr_hashes.map { |pr| Pr.new(pr) }
+
+      expect(prs.length).to eq(3)
+      expect(prs.first).to be_instance_of(Pr)
+      expect(prs.first.author).to eq('alice')
+      expect(prs.first.additions).to eq(120)
+    end
+  end
+end

--- a/spec/lib/pr_spec.rb
+++ b/spec/lib/pr_spec.rb
@@ -1,0 +1,194 @@
+require_relative '../spec_helper'
+
+describe 'Pr class' do
+  describe 'requested_review_open_pr' do
+    let(:pr_data) { load_fixture('requested_review_open_pr.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'returns correct author' do
+      expect(pr.author).to eq('ioanniswd')
+    end
+
+    it 'has review request with no reviews' do
+      expect(pr.requested_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'active_reviewers includes requested reviewer' do
+      expect(pr.active_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'reviewer is actionable (in review request)' do
+      expect(pr.reviewer_actionable?(user: 'ioanniswd-bot')).to be_truthy
+    end
+
+    it 'author is not actionable (waiting for review)' do
+      expect(pr.author_actionable?).to be_falsy
+    end
+  end
+
+  describe 'requested_changes_first_time' do
+    let(:pr_data) { load_fixture('requested_changes_first_time.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'has no review requests' do
+      expect(pr.requested_reviewers).to eq([])
+    end
+
+    it 'reviewer has requested changes in active reviewers' do
+      expect(pr.active_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'reviewer is not actionable (not in request list)' do
+      expect(pr.reviewer_actionable?(user: 'ioanniswd-bot')).to be_falsy
+    end
+
+    it 'author is actionable (changes requested)' do
+      expect(pr.author_actionable?).to be_truthy
+    end
+
+    it 'tracks untouched reviewers correctly' do
+      expect(pr.untouched_by('ioanniswd-bot')).to be_falsy
+    end
+  end
+
+  describe 're_requesting_review_after_requested_changes' do
+    let(:pr_data) { load_fixture('re_requesting_review_after_requested_changes.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'has review request after CHANGES_REQUESTED review' do
+      expect(pr.requested_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'active_reviewers includes re-requested reviewer' do
+      expect(pr.active_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'reviewer is actionable (re-requested for review)' do
+      expect(pr.reviewer_actionable?(user: 'ioanniswd-bot')).to be_truthy
+    end
+
+    it 'author is not actionable (awaiting re-review)' do
+      expect(pr.author_actionable?).to be_falsy
+    end
+  end
+
+  describe 're_requesting_changes_after_re_requesting_review' do
+    let(:pr_data) { load_fixture('re_requesting_changes_after_re_requesting_review.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'has no review requests' do
+      expect(pr.requested_reviewers).to eq([])
+    end
+
+    it 'latest review is CHANGES_REQUESTED in active reviewers' do
+      # CHANGES_REQUESTED → CHANGES_REQUESTED (re-requested)
+      expect(pr.active_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'reviewer is not actionable (not in request, just reviewed)' do
+      expect(pr.reviewer_actionable?(user: 'ioanniswd-bot')).to be_falsy
+    end
+
+    it 'author is actionable (changes requested again)' do
+      expect(pr.author_actionable?).to be_truthy
+    end
+  end
+
+  describe 'approved_after_requested_changes' do
+    let(:pr_data) { load_fixture('approved_after_requested_changes.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'has no review requests (already approved)' do
+      # CHANGES_REQUESTED → CHANGES_REQUESTED → APPROVED
+      expect(pr.requested_reviewers).to eq([])
+    end
+
+    it 'has no active reviewers (latest review state is APPROVED)' do
+      expect(pr.active_reviewers).to eq([])
+    end
+
+    it 'author is actionable (approved)' do
+      expect(pr.author_actionable?).to be_truthy
+    end
+
+    it 'has one approval' do
+      expect(pr.num_of_approvals).to eq(1)
+    end
+
+    it 'has one reviewer' do
+      expect(pr.num_of_reviewers).to eq(1)
+    end
+  end
+
+  describe 're_request_review_after_approval' do
+    let(:pr_data) { load_fixture('re_request_review_after_approval.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'has review request after APPROVED review' do
+      expect(pr.requested_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'active_reviewers includes re-requested reviewer' do
+      expect(pr.active_reviewers).to eq(['ioanniswd-bot'])
+    end
+
+    it 'reviewer is actionable (re-requested despite approval)' do
+      expect(pr.reviewer_actionable?(user: 'ioanniswd-bot')).to be_truthy
+    end
+
+    it 'author is not actionable (awaiting re-review)' do
+      expect(pr.author_actionable?).to be_falsy
+    end
+
+    it 'has no approvals' do
+      expect(pr.num_of_approvals).to eq(0)
+    end
+  end
+
+  describe 'approval_after_review_request_after_approval' do
+    let(:pr_data) { load_fixture('approval_after_review_request_after_approval.json').first }
+    let(:pr) { Pr.new(pr_data) }
+
+    it 'has no review requests' do
+      expect(pr.requested_reviewers).to eq([])
+    end
+
+    it 'has no active reviewers (latest review state is APPROVED)' do
+      expect(pr.active_reviewers).to eq([])
+    end
+
+    it 'reviewer is not actionable' do
+      expect(pr.reviewer_actionable?(user: 'ioanniswd-bot')).to be_falsy
+    end
+
+    it 'author is actionable (approved)' do
+      expect(pr.author_actionable?).to be_truthy
+    end
+
+    it 'has one approval (same user, multiple approval reviews)' do
+      expect(pr.num_of_approvals).to eq(1)
+    end
+
+    it 'has one reviewer (same person, multiple reviews)' do
+      expect(pr.num_of_reviewers).to eq(1)
+    end
+  end
+
+  describe 'edge cases' do
+    it 'handles PR with nil reviews gracefully' do
+      pr_data = {
+        'number' => 100,
+        'title' => 'Test',
+        'url' => 'http://example.com',
+        'author' => { 'login' => 'test' },
+        'additions' => 10,
+        'deletions' => 5,
+        'reviews' => nil,
+        'reviewRequests' => nil
+      }
+      pr = Pr.new(pr_data)
+      expect(pr.requested_reviewers).to eq([])
+      expect(pr.active_reviewers).to eq([])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,20 @@
+require 'rspec'
+require 'json'
+require_relative '../lib/pr'
+require_relative '../lib/services/github_client'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end
+
+# Helper to load fixture files
+def load_fixture(filename)
+  path = File.join(__dir__, 'fixtures', filename)
+  JSON.parse(File.read(path))
+end


### PR DESCRIPTION
**Desription:**
 - [x] Replace the current direct HTTP GraphQL implementation with GitHub CLI (`gh`) for improved reliability, better error handling, and built-in rate limit management.

**Other changes:**
 - [x] Add specs